### PR TITLE
feature/new-dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+################################################################################
+# Builder Stage
+################################################################################
+
+# we're deploying to the lts-alpine image, so do our building on it too
+FROM node:lts-alpine as builder
+
+# node-gyp runs as part of the npm install, so we need to install dependencies
+# we need git for cypress as it's using a custom version of requests that
+# they're maintaining now that the npm one's deprecated
+USER root
+RUN apk add --no-cache --virtual .build-deps \
+    python3 \
+    make \
+    g++ \
+    git
+
+# by default, we want to do everything in a non-privileged user, so go to their
+# home dir and drop to their account
+WORKDIR /home/node
+USER node
+
+# copy in the package files so that we can install and build the project
+# dependencies
+COPY --chown=node:node package*.json ./
+
+# install all the node modules required
+ENV NODE_ENV=production
+RUN npm ci && npm prune
+
+################################################################################
+# Deployable Image
+################################################################################
+
+# we built on the lts-alpine image, so we need to deploy on it too
+FROM node:lts-alpine
+
+# drop back to the non-privileged user for run-time
+WORKDIR /home/node
+USER node
+
+# copy the assets form the builder stage
+COPY --chown=node:node --from=builder /home/node/node_modules ./node_modules
+
+# copy the code from the project
+COPY --chown=node:node package*.json ./
+COPY --chown=node:node ./src ./src
+RUN mkdir -p ./dist
+
+# these variables are for overriding but keep them consistent between image and
+# run
+ENV FC_PORT 3008
+ENV FC_PATH_PREFIX fit-and-competent
+
+# this variable is for overriding and it only matters during run
+ENV FC_SESSION_SECRET override_this_value
+
+# let docker know about our listening port
+EXPOSE $FC_PORT
+
+# run the default start script, which kicks off a few pre-start things too
+CMD ["npm", "start"]


### PR DESCRIPTION
## Add a dockerfile to the project

This one uses...

```dockerfile
ENV NODE_ENV=production
RUN npm ci && npm prune
```

...instead of...

```dockerfile
RUN npm ci && npm prune --production
```

..to remove the devDependencies. It's quite a bit faster to prevent them from being installed by using the env var, as Cypress has a lot to download that isn't needed for the real deploy. The `npm prune` is _probably_ not required, but I've not tested removing it altogether.

Issue: Scottish-Natural-Heritage/Licensing#400