### PR TITLE
remove contact blocks

### DIFF
--- a/src/views/dsc1-details.njk
+++ b/src/views/dsc1-details.njk
@@ -153,21 +153,6 @@
           classes: "naturescot-forward-button"
           }) }}
         </form>
-      <h3 class="govuk-heading-s">Email</h3>
-      <ul class="govuk-list">
-        <li><a class="govuk-link" href="mailto:licensing@nature.scot">licensing@nature.scot</a></li>
-      </ul>
-      <h3 class="govuk-heading-s">Telephone</h3>
-      <ul class="govuk-list">
-        <li>01463 725 364</li>
-        <li>Monday to Friday, 10am to 4pm (except public holidays)</li>
-      </ul>
-      <p class="govuk-body">
-        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges&nbsp;(opens in new tab)</a>
-      </p>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
-        Back to top
-      </a>
     </div>
   </div>
 {% endblock %}

--- a/src/views/dsc2-details.njk
+++ b/src/views/dsc2-details.njk
@@ -153,21 +153,6 @@
           classes: "naturescot-forward-button"
           }) }}
         </form>
-      <h3 class="govuk-heading-s">Email</h3>
-      <ul class="govuk-list">
-        <li><a class="govuk-link" href="mailto:licensing@nature.scot">licensing@nature.scot</a></li>
-      </ul>
-      <h3 class="govuk-heading-s">Telephone</h3>
-      <ul class="govuk-list">
-        <li>01463 725 364</li>
-        <li>Monday to Friday, 10am to 4pm (except public holidays)</li>
-      </ul>
-      <p class="govuk-body">
-        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges&nbsp;(opens in new tab)</a>
-      </p>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
-        Back to top
-      </a>
     </div>
   </div>
 {% endblock %}

--- a/src/views/firearm.njk
+++ b/src/views/firearm.njk
@@ -162,9 +162,6 @@
       <p class="govuk-body">
         <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges&nbsp;(opens in new tab)</a>
       </p>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
-        Back to top
-      </a>
     </div>
   </div>
 {% endblock %}

--- a/src/views/firearm.njk
+++ b/src/views/firearm.njk
@@ -137,19 +137,14 @@
             ]
           }) }}
 
-          {{ govukWarningText({
-            text: '' +
-              'If you do not hold a Firearm Certificate and want to continue ' +
-              'with your application please contact the NatureScot Licensing ' +
-              'Team.',
-            iconFallbackText: "Warning"
-          }) }}
-
           {{ govukButton({
           text: "Continue",
           classes: "naturescot-forward-button"
           }) }}
         </form>
+      <p class="govuk-body">
+        If you do not hold a Firearm Certificate and want to continue with your application please contact the NatureScot Licensing Team.
+      </p>
       <h3 class="govuk-heading-s">Email</h3>
       <ul class="govuk-list">
         <li><a class="govuk-link" href="mailto:licensing@nature.scot">licensing@nature.scot</a></li>

--- a/src/views/gdpr.njk
+++ b/src/views/gdpr.njk
@@ -283,6 +283,9 @@
           classes: "naturescot-forward-button"
         }) }}
       </form>
+      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
+        Back to top
+      </a>
     </div>
   </div>
 {% endblock %}

--- a/src/views/other-qualification-details.njk
+++ b/src/views/other-qualification-details.njk
@@ -134,21 +134,6 @@
           classes: "naturescot-forward-button"
           }) }}
         </form>
-      <h3 class="govuk-heading-s">Email</h3>
-      <ul class="govuk-list">
-        <li><a class="govuk-link" href="mailto:licensing@nature.scot">licensing@nature.scot</a></li>
-      </ul>
-      <h3 class="govuk-heading-s">Telephone</h3>
-      <ul class="govuk-list">
-        <li>01463 725 364</li>
-        <li>Monday to Friday, 10am to 4pm (except public holidays)</li>
-      </ul>
-      <p class="govuk-body">
-        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges&nbsp;(opens in new tab)</a>
-      </p>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
-        Back to top
-      </a>
     </div>
   </div>
 {% endblock %}

--- a/src/views/qualification.njk
+++ b/src/views/qualification.njk
@@ -88,9 +88,6 @@
       <p class="govuk-body">
         <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges&nbsp;(opens in new tab)</a>
       </p>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
-        Back to top
-      </a>
     </div>
   </div>
 {% endblock %}

--- a/src/views/qualification.njk
+++ b/src/views/qualification.njk
@@ -67,15 +67,15 @@
             iconFallbackText: "Warning"
           }) }}
 
-        <p class="govuk-body">
-          If you do not hold a DSC Level 1 or 2 or equivalent and still want to apply then contact the NatureScot Licensing Team 
-          for advice.
-        </p>
           {{ govukButton({
           text: "Continue",
           classes: "naturescot-forward-button"
           }) }}
         </form>
+        <p class="govuk-body">
+          If you do not hold a DSC Level 1 or 2 or equivalent and still want to apply then contact the NatureScot Licensing Team 
+          for advice.
+        </p>
       <h3 class="govuk-heading-s">Email</h3>
       <ul class="govuk-list">
         <li><a class="govuk-link" href="mailto:licensing@nature.scot">licensing@nature.scot</a></li>

--- a/src/views/red-experience.njk
+++ b/src/views/red-experience.njk
@@ -125,23 +125,6 @@
       classes: "naturescot-forward-button"
       }) }}
     </form>
-
-      
-      <h3 class="govuk-heading-s">Email</h3>
-      <ul class="govuk-list">
-        <li><a class="govuk-link" href="mailto:licensing@nature.scot">licensing@nature.scot</a></li>
-      </ul>
-      <h3 class="govuk-heading-s">Telephone</h3>
-      <ul class="govuk-list">
-        <li>01463 725 364</li>
-        <li>Monday to Friday, 10am to 4pm (except public holidays)</li>
-      </ul>
-      <p class="govuk-body">
-        <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.gov.uk/call-charges">Find out about call charges&nbsp;(opens in new tab)</a>
-      </p>
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-font-size-16" href="#top-of-page">
-        Back to top
-      </a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
remove contact blocks and back to top links from pages that do not require them

Issue: Scottish-Natural-Heritage/Licensing#405